### PR TITLE
Added input-tablet icon

### DIFF
--- a/Breeze Dark/devices/64/input-tablet.svg
+++ b/Breeze Dark/devices/64/input-tablet.svg
@@ -1,0 +1,359 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="32"
+   id="svg5453"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   sodipodi:docname="preferences-desktop-peripherals.svg">
+  <defs
+     id="defs5455">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4222">
+      <stop
+         style="stop-color:#147de1;stop-opacity:1"
+         offset="0"
+         id="stop4224" />
+      <stop
+         id="stop4226"
+         offset="0.69999999"
+         style="stop-color:#88bff4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3995ed;stop-opacity:1"
+         offset="1"
+         id="stop4228" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4204"
+       inkscape:collect="always">
+      <stop
+         id="stop4206"
+         offset="0"
+         style="stop-color:#23262c;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e5462;stop-opacity:1"
+         offset="0.69999999"
+         id="stop4208" />
+      <stop
+         id="stop4210"
+         offset="1"
+         style="stop-color:#23262c;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188">
+      <stop
+         style="stop-color:#74868f;stop-opacity:1"
+         offset="0"
+         id="stop4190" />
+      <stop
+         id="stop4194"
+         offset="0.69999999"
+         style="stop-color:#d3d9dc;stop-opacity:1;" />
+      <stop
+         style="stop-color:#d6dddf;stop-opacity:1"
+         offset="1"
+         id="stop4192" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4177">
+      <stop
+         style="stop-color:#f2f2f2;stop-opacity:1"
+         offset="0"
+         id="stop4179" />
+      <stop
+         style="stop-color:#f9f9f9;stop-opacity:1"
+         offset="1"
+         id="stop4181" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4303-6"
+       id="linearGradient4643"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66666726,0,0,0.68055543,128.19017,175.71333)"
+       x1="409.57144"
+       y1="543.79797"
+       x2="409.57144"
+       y2="502.65509" />
+    <linearGradient
+       id="linearGradient4303-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4305-7"
+         offset="0"
+         style="stop-color:#c6cdd1;stop-opacity:1" />
+      <stop
+         id="stop4307-0"
+         offset="1"
+         style="stop-color:#e0e5e7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4177"
+       id="linearGradient4183"
+       x1="400.57144"
+       y1="540.79797"
+       x2="400.57144"
+       y2="524.79797"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188"
+       id="linearGradient4169"
+       x1="407.57144"
+       y1="536.79797"
+       x2="408.57144"
+       y2="536.79797"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4204"
+       id="linearGradient4202"
+       x1="407.57144"
+       y1="530.29797"
+       x2="408.57144"
+       y2="530.29797"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4222"
+       id="linearGradient4220"
+       x1="407.57144"
+       y1="538.29797"
+       x2="408.57144"
+       y2="538.29797"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4204"
+       id="linearGradient4241"
+       x1="23"
+       y1="23.5"
+       x2="24"
+       y2="23.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4227"
+       id="linearGradient4187"
+       x1="400.57144"
+       y1="525.79797"
+       x2="414.57147"
+       y2="539.79797"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-384.57143,-515.798)" />
+    <linearGradient
+       id="linearGradient4227"
+       inkscape:collect="always">
+      <stop
+         id="stop4229"
+         offset="0"
+         style="stop-color:#292c2f;stop-opacity:1" />
+      <stop
+         id="stop4231"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.181126"
+     inkscape:cx="3.3925798"
+     inkscape:cy="16.737115"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4063" />
+    <sodipodi:guide
+       position="4.2167969e-05,32.000026"
+       orientation="32,0"
+       id="guide4625" />
+    <sodipodi:guide
+       position="4.2167969e-05,2.6367188e-05"
+       orientation="0,31.999969"
+       id="guide4627" />
+    <sodipodi:guide
+       position="32.000012,2.6367188e-05"
+       orientation="-32,0"
+       id="guide4629" />
+    <sodipodi:guide
+       position="32.000012,32.000026"
+       orientation="0,-31.999969"
+       id="guide4631" />
+    <sodipodi:guide
+       position="2.0000422,30.000026"
+       orientation="28,0"
+       id="guide4633" />
+    <sodipodi:guide
+       position="-44,2"
+       orientation="0,27.999969"
+       id="guide4635" />
+    <sodipodi:guide
+       position="30.000012,30.000026"
+       orientation="0,-27.999969"
+       id="guide4639" />
+    <sodipodi:guide
+       position="30,4"
+       orientation="0,-5"
+       id="guide4190" />
+    <sodipodi:guide
+       position="25,4"
+       orientation="0,5"
+       id="guide4192" />
+    <sodipodi:guide
+       position="30,4"
+       orientation="0,-1"
+       id="guide4194" />
+    <sodipodi:guide
+       position="29,4"
+       orientation="0,-1.5"
+       id="guide4196" />
+    <sodipodi:guide
+       position="16.000012,22.000026"
+       orientation="14,0"
+       id="guide4188" />
+    <sodipodi:guide
+       position="16.000012,8.0000264"
+       orientation="0,14"
+       id="guide4191" />
+    <sodipodi:guide
+       position="30.000012,8.0000264"
+       orientation="-14,0"
+       id="guide4193" />
+    <sodipodi:guide
+       position="30.000012,22.000026"
+       orientation="0,-14"
+       id="guide4195" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5458">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-384.57143,-515.798)">
+    <rect
+       ry="0"
+       y="517.79797"
+       x="384.57144"
+       height="28"
+       width="32"
+       id="rect4641"
+       style="opacity:1;fill:url(#linearGradient4643);fill-opacity:1;stroke:none" />
+    <rect
+       style="opacity:1;fill:#23262c;fill-opacity:1;stroke:none"
+       id="rect4647"
+       width="32"
+       height="5.0000262"
+       x="384.57144"
+       y="517.79797" />
+    <rect
+       style="opacity:1;fill:#3995ed;fill-opacity:1;stroke:none"
+       id="rect4171"
+       width="3"
+       height="1"
+       x="411.5715"
+       y="519.79797" />
+    <rect
+       y="519.79797"
+       x="386.57144"
+       height="1"
+       width="3"
+       id="rect4173"
+       style="opacity:1;fill:#ebf4fd;fill-opacity:1;stroke:none" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4183);fill-opacity:1;stroke:none"
+       id="rect4175"
+       width="26"
+       height="16"
+       x="387.57144"
+       y="524.79797" />
+    <rect
+       style="opacity:1;fill:#cad3d6;fill-opacity:1;stroke:none"
+       id="rect4185"
+       width="26"
+       height="1"
+       x="387.57144"
+       y="524.79797" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4202);fill-opacity:1.0;stroke:none"
+       id="rect4159"
+       width="0.99998838"
+       height="7.0000262"
+       x="407.57144"
+       y="526.79797" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4169);fill-opacity:1;stroke:none"
+       id="rect4161"
+       width="1"
+       height="5.0000262"
+       x="407.57144"
+       y="533.79797" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4220);fill-opacity:1.0;stroke:none"
+       id="rect4212"
+       width="1"
+       height="1"
+       x="407.57144"
+       y="537.79797" />
+    <path
+       style="fill:url(#linearGradient4187);fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1;opacity:0.2"
+       d="M 24 11 L 23.5 24 L 27.5 28 L 29.5 30 L 32 30 L 32 19 L 30 17 L 24 11 z "
+       transform="translate(384.57143,515.798)"
+       id="path4179" />
+    <path
+       style="fill:url(#linearGradient4241);fill-opacity:1.0;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 23 23 L 23 23.300781 L 23.5 24 L 24 23.300781 L 24 23 L 23 23 z "
+       transform="translate(384.57143,515.798)"
+       id="path4230" />
+    <rect
+       style="opacity:1;fill:#23262c;fill-opacity:1;stroke:none"
+       id="rect4645"
+       width="32"
+       height="2"
+       x="384.57144"
+       y="543.79797" />
+  </g>
+</svg>

--- a/Breeze Dark/devices/64/input-tablet.svg
+++ b/Breeze Dark/devices/64/input-tablet.svg
@@ -10,163 +10,222 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="32"
-   height="32"
+   width="64"
+   height="64"
    id="svg5453"
    version="1.1"
-   inkscape:version="0.91+devel r"
-   sodipodi:docname="preferences-desktop-peripherals.svg">
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="input-tablet.svg"
+   inkscape:export-filename="input-tablet.png"
+   inkscape:export-xdpi="180"
+   inkscape:export-ydpi="180">
   <defs
      id="defs5455">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4222">
-      <stop
-         style="stop-color:#147de1;stop-opacity:1"
-         offset="0"
-         id="stop4224" />
-      <stop
-         id="stop4226"
-         offset="0.69999999"
-         style="stop-color:#88bff4;stop-opacity:1" />
-      <stop
-         style="stop-color:#3995ed;stop-opacity:1"
-         offset="1"
-         id="stop4228" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4204"
+       id="linearGradient4303"
        inkscape:collect="always">
       <stop
-         id="stop4206"
-         offset="0"
-         style="stop-color:#23262c;stop-opacity:1" />
-      <stop
-         style="stop-color:#4e5462;stop-opacity:1"
-         offset="0.69999999"
-         id="stop4208" />
-      <stop
-         id="stop4210"
-         offset="1"
-         style="stop-color:#23262c;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4188">
-      <stop
-         style="stop-color:#74868f;stop-opacity:1"
-         offset="0"
-         id="stop4190" />
-      <stop
-         id="stop4194"
-         offset="0.69999999"
-         style="stop-color:#d3d9dc;stop-opacity:1;" />
-      <stop
-         style="stop-color:#d6dddf;stop-opacity:1"
-         offset="1"
-         id="stop4192" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4177">
-      <stop
-         style="stop-color:#f2f2f2;stop-opacity:1"
-         offset="0"
-         id="stop4179" />
-      <stop
-         style="stop-color:#f9f9f9;stop-opacity:1"
-         offset="1"
-         id="stop4181" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4303-6"
-       id="linearGradient4643"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666726,0,0,0.68055543,128.19017,175.71333)"
-       x1="409.57144"
-       y1="543.79797"
-       x2="409.57144"
-       y2="502.65509" />
-    <linearGradient
-       id="linearGradient4303-6"
-       inkscape:collect="always">
-      <stop
-         id="stop4305-7"
+         id="stop4305"
          offset="0"
          style="stop-color:#c6cdd1;stop-opacity:1" />
       <stop
-         id="stop4307-0"
+         id="stop4307"
          offset="1"
          style="stop-color:#e0e5e7;stop-opacity:1" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4177"
-       id="linearGradient4183"
+       id="linearGradient5002">
+      <stop
+         style="stop-color:#2e5d89;stop-opacity:1"
+         offset="0"
+         id="stop5004" />
+      <stop
+         style="stop-color:#1b92f4;stop-opacity:1"
+         offset="1"
+         id="stop5006" />
+    </linearGradient>
+    <linearGradient
+       y2="527.79797"
+       x2="415.57144"
+       y1="512.79797"
        x1="400.57144"
-       y1="540.79797"
-       x2="400.57144"
-       y2="524.79797"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4188"
-       id="linearGradient4169"
-       x1="407.57144"
-       y1="536.79797"
-       x2="408.57144"
-       y2="536.79797"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4204"
-       id="linearGradient4202"
-       x1="407.57144"
-       y1="530.29797"
-       x2="408.57144"
-       y2="530.29797"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4222"
-       id="linearGradient4220"
-       x1="407.57144"
-       y1="538.29797"
-       x2="408.57144"
-       y2="538.29797"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4204"
-       id="linearGradient4241"
-       x1="23"
-       y1="23.5"
-       x2="24"
-       y2="23.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4227"
-       id="linearGradient4187"
-       x1="400.57144"
-       y1="525.79797"
-       x2="414.57147"
-       y2="539.79797"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-384.57143,-515.798)" />
+       id="linearGradient4352"
+       xlink:href="#linearGradient5002"
+       inkscape:collect="always"
+       gradientTransform="matrix(1.1818182,0,0,1.1818182,-74.285714,-95.732083)" />
     <linearGradient
-       id="linearGradient4227"
+       y2="527.79797"
+       x2="415.57144"
+       y1="512.79797"
+       x1="400.57144"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4352-6"
+       xlink:href="#linearGradient5002"
+       inkscape:collect="always"
+       gradientTransform="translate(78.999997,3.6562389)" />
+    <linearGradient
+       gradientTransform="matrix(1.1818182,0,0,1.1818182,6.714285,-89.23598)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient5002"
+       id="linearGradient4352-5"
+       gradientUnits="userSpaceOnUse"
+       x1="400.57144"
+       y1="512.79797"
+       x2="415.57144"
+       y2="527.79797" />
+    <linearGradient
+       gradientTransform="matrix(1.1818182,0,0,1.1818182,3.714275,-96.23596)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient5002"
+       id="linearGradient4352-9"
+       gradientUnits="userSpaceOnUse"
+       x1="400.57144"
+       y1="512.79797"
+       x2="415.57144"
+       y2="527.79797" />
+    <linearGradient
+       id="linearGradient4222"
        inkscape:collect="always">
       <stop
-         id="stop4229"
+         id="stop4224"
          offset="0"
-         style="stop-color:#292c2f;stop-opacity:1" />
+         style="stop-color:#147de1;stop-opacity:1" />
       <stop
-         id="stop4231"
+         style="stop-color:#88bff4;stop-opacity:1"
+         offset="0.69999999"
+         id="stop4226" />
+      <stop
+         id="stop4228"
          offset="1"
-         style="stop-color:#000000;stop-opacity:0;" />
+         style="stop-color:#3995ed;stop-opacity:1" />
     </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4204">
+      <stop
+         style="stop-color:#23262c;stop-opacity:1"
+         offset="0"
+         id="stop4206" />
+      <stop
+         id="stop4208"
+         offset="0.69999999"
+         style="stop-color:#4e5462;stop-opacity:1" />
+      <stop
+         style="stop-color:#23262c;stop-opacity:1"
+         offset="1"
+         id="stop4210" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4188"
+       inkscape:collect="always">
+      <stop
+         id="stop4190"
+         offset="0"
+         style="stop-color:#74868f;stop-opacity:1" />
+      <stop
+         style="stop-color:#d3d9dc;stop-opacity:1;"
+         offset="0.69999999"
+         id="stop4194" />
+      <stop
+         id="stop4192"
+         offset="1"
+         style="stop-color:#d6dddf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4177"
+       inkscape:collect="always">
+      <stop
+         id="stop4179"
+         offset="0"
+         style="stop-color:#f2f2f2;stop-opacity:1" />
+      <stop
+         id="stop4181"
+         offset="1"
+         style="stop-color:#f9f9f9;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="502.65509"
+       x2="409.57144"
+       y1="541.98621"
+       x1="409.4946"
+       gradientTransform="matrix(1.0833349,0,0,1.1059032,-34.048348,-55.586311)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4643"
+       xlink:href="#linearGradient4303"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="536.79797"
+       x2="408.57144"
+       y1="536.79797"
+       x1="407.34808"
+       id="linearGradient4169"
+       xlink:href="#linearGradient4188"
+       inkscape:collect="always"
+       gradientTransform="matrix(1.6348918,0,0,1.6348918,-246.39863,-346.45972)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="530.29797"
+       x2="408.57144"
+       y1="530.29797"
+       x1="407.34808"
+       id="linearGradient4202"
+       xlink:href="#linearGradient4204"
+       inkscape:collect="always"
+       gradientTransform="matrix(1.6348918,0,0,1.6348918,-246.39863,-346.45972)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="538.29797"
+       x2="408.57144"
+       y1="538.29797"
+       x1="407.34808"
+       id="linearGradient4220"
+       xlink:href="#linearGradient4222"
+       inkscape:collect="always"
+       gradientTransform="matrix(1.6348918,0,0,1.6348918,-246.39863,-346.45972)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="23.5"
+       x2="24"
+       y1="23.5"
+       x1="22.776661"
+       id="linearGradient4241"
+       xlink:href="#linearGradient4204"
+       inkscape:collect="always"
+       gradientTransform="matrix(1.6348918,0,0,1.6348918,382.33405,496.8142)" />
+    <linearGradient
+       gradientTransform="matrix(1.6250009,0,0,1.6250009,-242.35749,-341.12063)"
+       gradientUnits="userSpaceOnUse"
+       y2="539.79797"
+       x2="414.57147"
+       y1="525.79797"
+       x1="400.57144"
+       id="linearGradient4187"
+       xlink:href="#linearGradient4227"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4227">
+      <stop
+         style="stop-color:#292c2f;stop-opacity:1"
+         offset="0"
+         id="stop4229" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4231" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4177"
+       id="linearGradient4337"
+       x1="386.57144"
+       y1="525.79797"
+       x2="429.57144"
+       y2="525.79797"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -175,9 +234,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="11.181126"
-     inkscape:cx="3.3925798"
-     inkscape:cy="16.737115"
+     inkscape:zoom="0.125"
+     inkscape:cx="-1163.0533"
+     inkscape:cy="-189.05629"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -185,77 +244,49 @@
      fit-margin-left="0"
      fit-margin-right="0"
      fit-margin-bottom="0"
-     inkscape:window-width="1366"
-     inkscape:window-height="670"
-     inkscape:window-x="-4"
-     inkscape:window-y="29"
+     inkscape:window-width="1920"
+     inkscape:window-height="1006"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
      inkscape:showpageshadow="false"
      borderlayer="true"
-     showguides="true">
+     showguides="true"
+     inkscape:snap-bbox="true"
+     inkscape:object-nodes="true">
     <inkscape:grid
        type="xygrid"
-       id="grid4063" />
+       id="grid4063"
+       originx="7.9999866px"
+       originy="7.9999772px" />
     <sodipodi:guide
-       position="4.2167969e-05,32.000026"
-       orientation="32,0"
-       id="guide4625" />
-    <sodipodi:guide
-       position="4.2167969e-05,2.6367188e-05"
-       orientation="0,31.999969"
-       id="guide4627" />
-    <sodipodi:guide
-       position="32.000012,2.6367188e-05"
-       orientation="-32,0"
-       id="guide4629" />
-    <sodipodi:guide
-       position="32.000012,32.000026"
-       orientation="0,-31.999969"
-       id="guide4631" />
-    <sodipodi:guide
-       position="2.0000422,30.000026"
-       orientation="28,0"
-       id="guide4633" />
-    <sodipodi:guide
-       position="-44,2"
-       orientation="0,27.999969"
-       id="guide4635" />
-    <sodipodi:guide
-       position="30.000012,30.000026"
-       orientation="0,-27.999969"
-       id="guide4639" />
-    <sodipodi:guide
-       position="30,4"
-       orientation="0,-5"
-       id="guide4190" />
-    <sodipodi:guide
-       position="25,4"
-       orientation="0,5"
-       id="guide4192" />
-    <sodipodi:guide
-       position="30,4"
-       orientation="0,-1"
-       id="guide4194" />
-    <sodipodi:guide
-       position="29,4"
-       orientation="0,-1.5"
+       position="0,0"
+       orientation="0,64"
        id="guide4196" />
     <sodipodi:guide
-       position="16.000012,22.000026"
-       orientation="14,0"
-       id="guide4188" />
+       position="64,0"
+       orientation="-64,0"
+       id="guide4198" />
     <sodipodi:guide
-       position="16.000012,8.0000264"
-       orientation="0,14"
-       id="guide4191" />
+       position="64,64"
+       orientation="0,-64"
+       id="guide4200" />
     <sodipodi:guide
-       position="30.000012,8.0000264"
-       orientation="-14,0"
-       id="guide4193" />
+       position="6,58"
+       orientation="52,0"
+       id="guide4202" />
     <sodipodi:guide
-       position="30.000012,22.000026"
-       orientation="0,-14"
-       id="guide4195" />
+       position="6,6"
+       orientation="0,52"
+       id="guide4204" />
+    <sodipodi:guide
+       position="58,6"
+       orientation="-52,0"
+       id="guide4206" />
+    <sodipodi:guide
+       position="58,58"
+       orientation="0,-52"
+       id="guide4208" />
   </sodipodi:namedview>
   <metadata
      id="metadata5458">
@@ -273,87 +304,113 @@
      inkscape:label="Capa 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(-384.57143,-515.798)">
-    <rect
-       ry="0"
-       y="517.79797"
-       x="384.57144"
-       height="28"
-       width="32"
+     transform="translate(-376.57144,-491.79797)"
+     style="display:inline">
+    <path
+       id="circle4309-6"
+       style="opacity:1;fill:url(#linearGradient4352);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       r="9.9999886"
+       cy="519.79797"
+       cx="408.57144"
+       d=""
+       inkscape:connector-curvature="0" />
+    <path
+       id="circle4309-6-0"
+       style="opacity:1;fill:url(#linearGradient4352-6);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       r="9.9999886"
+       cy="519.79797"
+       cx="408.57144"
+       d=""
+       inkscape:connector-curvature="0" />
+    <path
+       id="circle4309-6-7"
+       style="opacity:1;fill:url(#linearGradient4352-5);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       r="9.9999886"
+       cy="519.79797"
+       cx="408.57144"
+       d=""
+       inkscape:connector-curvature="0" />
+    <path
+       id="circle4309-6-4"
+       style="opacity:1;fill:url(#linearGradient4352-9);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       r="9.9999886"
+       cy="519.79797"
+       cx="408.57144"
+       d=""
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
        id="rect4641"
+       d="m 382.57145,506.79799 52.00002,0 0,37.00357 -52.00002,0 z"
        style="opacity:1;fill:url(#linearGradient4643);fill-opacity:1;stroke:none" />
-    <rect
-       style="opacity:1;fill:#23262c;fill-opacity:1;stroke:none"
+    <path
+       style="opacity:1;fill:url(#linearGradient4337);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 386.57144,511.79799 43.99999,0 0,26.99998 -43.99999,0 z"
+       id="rect4329"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.2;fill:url(#linearGradient4187);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 421.57145,513.79799 -1.00002,23 8,8 6.00003,0 0,-17.99999 z"
+       id="path4179"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
        id="rect4647"
-       width="32"
-       height="5.0000262"
-       x="384.57144"
-       y="517.79797" />
-    <rect
-       style="opacity:1;fill:#3995ed;fill-opacity:1;stroke:none"
-       id="rect4171"
-       width="3"
-       height="1"
-       x="411.5715"
-       y="519.79797" />
-    <rect
-       y="519.79797"
-       x="386.57144"
-       height="1"
-       width="3"
-       id="rect4173"
-       style="opacity:1;fill:#ebf4fd;fill-opacity:1;stroke:none" />
-    <rect
-       style="opacity:1;fill:url(#linearGradient4183);fill-opacity:1;stroke:none"
-       id="rect4175"
-       width="26"
-       height="16"
-       x="387.57144"
-       y="524.79797" />
-    <rect
-       style="opacity:1;fill:#cad3d6;fill-opacity:1;stroke:none"
-       id="rect4185"
-       width="26"
-       height="1"
-       x="387.57144"
-       y="524.79797" />
-    <rect
-       style="opacity:1;fill:url(#linearGradient4202);fill-opacity:1.0;stroke:none"
+       d="m 382.57145,500.7932 52.00002,0 0,7.00448 -52.00002,0 z"
+       style="opacity:1;fill:#23262c;fill-opacity:1;stroke:none" />
+    <path
+       style="opacity:1;fill:url(#linearGradient4202);fill-opacity:1;stroke:none"
+       d="m 419.57143,513.79799 2.00003,0 0,12 -2.00003,0 z"
        id="rect4159"
-       width="0.99998838"
-       height="7.0000262"
-       x="407.57144"
-       y="526.79797" />
-    <rect
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
        style="opacity:1;fill:url(#linearGradient4169);fill-opacity:1;stroke:none"
+       d="m 419.57143,525.79799 2.00005,0 0,8.61876 -2.00005,0 z"
        id="rect4161"
-       width="1"
-       height="5.0000262"
-       x="407.57144"
-       y="533.79797" />
-    <rect
-       style="opacity:1;fill:url(#linearGradient4220);fill-opacity:1.0;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="opacity:1;fill:url(#linearGradient4220);fill-opacity:1;stroke:none"
+       d="m 419.57143,532.79799 2.00005,0 0,1.6187 -2.00005,0 z"
        id="rect4212"
-       width="1"
-       height="1"
-       x="407.57144"
-       y="537.79797" />
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
     <path
-       style="fill:url(#linearGradient4187);fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1;opacity:0.2"
-       d="M 24 11 L 23.5 24 L 27.5 28 L 29.5 30 L 32 30 L 32 19 L 30 17 L 24 11 z "
-       transform="translate(384.57143,515.798)"
-       id="path4179" />
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient4241);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 419.57143,534.41671 0,0.38128 1,2 1.00002,-2 0,-0.38128 z"
+       id="path4230"
+       sodipodi:nodetypes="cccccc" />
     <path
-       style="fill:url(#linearGradient4241);fill-opacity:1.0;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 23 23 L 23 23.300781 L 23.5 24 L 24 23.300781 L 24 23 L 23 23 z "
-       transform="translate(384.57143,515.798)"
-       id="path4230" />
-    <rect
        style="opacity:1;fill:#23262c;fill-opacity:1;stroke:none"
+       d="m 382.57144,542.79799 52.00003,0 0,2 -52.00003,0 z"
        id="rect4645"
-       width="32"
-       height="2"
-       x="384.57144"
-       y="543.79797" />
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       y="503.798"
+       x="385.57141"
+       height="1"
+       width="5"
+       id="rect4303"
+       style="opacity:1;fill:#ebf4fd;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="503.798"
+       x="426.57144"
+       height="1"
+       width="5"
+       id="rect4305"
+       style="opacity:1;fill:#3995ed;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:#cad3d6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 386.57144,510.79799 44,0 0,2.00001 -44,0 z"
+       id="rect4326"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
   </g>
 </svg>

--- a/Breeze/devices/64/input-tablet.svg
+++ b/Breeze/devices/64/input-tablet.svg
@@ -1,0 +1,359 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="32"
+   id="svg5453"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   sodipodi:docname="preferences-desktop-peripherals.svg">
+  <defs
+     id="defs5455">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4222">
+      <stop
+         style="stop-color:#147de1;stop-opacity:1"
+         offset="0"
+         id="stop4224" />
+      <stop
+         id="stop4226"
+         offset="0.69999999"
+         style="stop-color:#88bff4;stop-opacity:1" />
+      <stop
+         style="stop-color:#3995ed;stop-opacity:1"
+         offset="1"
+         id="stop4228" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4204"
+       inkscape:collect="always">
+      <stop
+         id="stop4206"
+         offset="0"
+         style="stop-color:#23262c;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e5462;stop-opacity:1"
+         offset="0.69999999"
+         id="stop4208" />
+      <stop
+         id="stop4210"
+         offset="1"
+         style="stop-color:#23262c;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188">
+      <stop
+         style="stop-color:#74868f;stop-opacity:1"
+         offset="0"
+         id="stop4190" />
+      <stop
+         id="stop4194"
+         offset="0.69999999"
+         style="stop-color:#d3d9dc;stop-opacity:1;" />
+      <stop
+         style="stop-color:#d6dddf;stop-opacity:1"
+         offset="1"
+         id="stop4192" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4177">
+      <stop
+         style="stop-color:#f2f2f2;stop-opacity:1"
+         offset="0"
+         id="stop4179" />
+      <stop
+         style="stop-color:#f9f9f9;stop-opacity:1"
+         offset="1"
+         id="stop4181" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4303-6"
+       id="linearGradient4643"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66666726,0,0,0.68055543,128.19017,175.71333)"
+       x1="409.57144"
+       y1="543.79797"
+       x2="409.57144"
+       y2="502.65509" />
+    <linearGradient
+       id="linearGradient4303-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4305-7"
+         offset="0"
+         style="stop-color:#c6cdd1;stop-opacity:1" />
+      <stop
+         id="stop4307-0"
+         offset="1"
+         style="stop-color:#e0e5e7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4177"
+       id="linearGradient4183"
+       x1="400.57144"
+       y1="540.79797"
+       x2="400.57144"
+       y2="524.79797"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188"
+       id="linearGradient4169"
+       x1="407.57144"
+       y1="536.79797"
+       x2="408.57144"
+       y2="536.79797"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4204"
+       id="linearGradient4202"
+       x1="407.57144"
+       y1="530.29797"
+       x2="408.57144"
+       y2="530.29797"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4222"
+       id="linearGradient4220"
+       x1="407.57144"
+       y1="538.29797"
+       x2="408.57144"
+       y2="538.29797"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4204"
+       id="linearGradient4241"
+       x1="23"
+       y1="23.5"
+       x2="24"
+       y2="23.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4227"
+       id="linearGradient4187"
+       x1="400.57144"
+       y1="525.79797"
+       x2="414.57147"
+       y2="539.79797"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-384.57143,-515.798)" />
+    <linearGradient
+       id="linearGradient4227"
+       inkscape:collect="always">
+      <stop
+         id="stop4229"
+         offset="0"
+         style="stop-color:#292c2f;stop-opacity:1" />
+      <stop
+         id="stop4231"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.181126"
+     inkscape:cx="3.3925798"
+     inkscape:cy="16.737115"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4063" />
+    <sodipodi:guide
+       position="4.2167969e-05,32.000026"
+       orientation="32,0"
+       id="guide4625" />
+    <sodipodi:guide
+       position="4.2167969e-05,2.6367188e-05"
+       orientation="0,31.999969"
+       id="guide4627" />
+    <sodipodi:guide
+       position="32.000012,2.6367188e-05"
+       orientation="-32,0"
+       id="guide4629" />
+    <sodipodi:guide
+       position="32.000012,32.000026"
+       orientation="0,-31.999969"
+       id="guide4631" />
+    <sodipodi:guide
+       position="2.0000422,30.000026"
+       orientation="28,0"
+       id="guide4633" />
+    <sodipodi:guide
+       position="-44,2"
+       orientation="0,27.999969"
+       id="guide4635" />
+    <sodipodi:guide
+       position="30.000012,30.000026"
+       orientation="0,-27.999969"
+       id="guide4639" />
+    <sodipodi:guide
+       position="30,4"
+       orientation="0,-5"
+       id="guide4190" />
+    <sodipodi:guide
+       position="25,4"
+       orientation="0,5"
+       id="guide4192" />
+    <sodipodi:guide
+       position="30,4"
+       orientation="0,-1"
+       id="guide4194" />
+    <sodipodi:guide
+       position="29,4"
+       orientation="0,-1.5"
+       id="guide4196" />
+    <sodipodi:guide
+       position="16.000012,22.000026"
+       orientation="14,0"
+       id="guide4188" />
+    <sodipodi:guide
+       position="16.000012,8.0000264"
+       orientation="0,14"
+       id="guide4191" />
+    <sodipodi:guide
+       position="30.000012,8.0000264"
+       orientation="-14,0"
+       id="guide4193" />
+    <sodipodi:guide
+       position="30.000012,22.000026"
+       orientation="0,-14"
+       id="guide4195" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5458">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-384.57143,-515.798)">
+    <rect
+       ry="0"
+       y="517.79797"
+       x="384.57144"
+       height="28"
+       width="32"
+       id="rect4641"
+       style="opacity:1;fill:url(#linearGradient4643);fill-opacity:1;stroke:none" />
+    <rect
+       style="opacity:1;fill:#23262c;fill-opacity:1;stroke:none"
+       id="rect4647"
+       width="32"
+       height="5.0000262"
+       x="384.57144"
+       y="517.79797" />
+    <rect
+       style="opacity:1;fill:#3995ed;fill-opacity:1;stroke:none"
+       id="rect4171"
+       width="3"
+       height="1"
+       x="411.5715"
+       y="519.79797" />
+    <rect
+       y="519.79797"
+       x="386.57144"
+       height="1"
+       width="3"
+       id="rect4173"
+       style="opacity:1;fill:#ebf4fd;fill-opacity:1;stroke:none" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4183);fill-opacity:1;stroke:none"
+       id="rect4175"
+       width="26"
+       height="16"
+       x="387.57144"
+       y="524.79797" />
+    <rect
+       style="opacity:1;fill:#cad3d6;fill-opacity:1;stroke:none"
+       id="rect4185"
+       width="26"
+       height="1"
+       x="387.57144"
+       y="524.79797" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4202);fill-opacity:1.0;stroke:none"
+       id="rect4159"
+       width="0.99998838"
+       height="7.0000262"
+       x="407.57144"
+       y="526.79797" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4169);fill-opacity:1;stroke:none"
+       id="rect4161"
+       width="1"
+       height="5.0000262"
+       x="407.57144"
+       y="533.79797" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4220);fill-opacity:1.0;stroke:none"
+       id="rect4212"
+       width="1"
+       height="1"
+       x="407.57144"
+       y="537.79797" />
+    <path
+       style="fill:url(#linearGradient4187);fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1;opacity:0.2"
+       d="M 24 11 L 23.5 24 L 27.5 28 L 29.5 30 L 32 30 L 32 19 L 30 17 L 24 11 z "
+       transform="translate(384.57143,515.798)"
+       id="path4179" />
+    <path
+       style="fill:url(#linearGradient4241);fill-opacity:1.0;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 23 23 L 23 23.300781 L 23.5 24 L 24 23.300781 L 24 23 L 23 23 z "
+       transform="translate(384.57143,515.798)"
+       id="path4230" />
+    <rect
+       style="opacity:1;fill:#23262c;fill-opacity:1;stroke:none"
+       id="rect4645"
+       width="32"
+       height="2"
+       x="384.57144"
+       y="543.79797" />
+  </g>
+</svg>

--- a/Breeze/devices/64/input-tablet.svg
+++ b/Breeze/devices/64/input-tablet.svg
@@ -10,163 +10,222 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="32"
-   height="32"
+   width="64"
+   height="64"
    id="svg5453"
    version="1.1"
-   inkscape:version="0.91+devel r"
-   sodipodi:docname="preferences-desktop-peripherals.svg">
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="input-tablet.svg"
+   inkscape:export-filename="input-tablet.png"
+   inkscape:export-xdpi="180"
+   inkscape:export-ydpi="180">
   <defs
      id="defs5455">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4222">
-      <stop
-         style="stop-color:#147de1;stop-opacity:1"
-         offset="0"
-         id="stop4224" />
-      <stop
-         id="stop4226"
-         offset="0.69999999"
-         style="stop-color:#88bff4;stop-opacity:1" />
-      <stop
-         style="stop-color:#3995ed;stop-opacity:1"
-         offset="1"
-         id="stop4228" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4204"
+       id="linearGradient4303"
        inkscape:collect="always">
       <stop
-         id="stop4206"
-         offset="0"
-         style="stop-color:#23262c;stop-opacity:1" />
-      <stop
-         style="stop-color:#4e5462;stop-opacity:1"
-         offset="0.69999999"
-         id="stop4208" />
-      <stop
-         id="stop4210"
-         offset="1"
-         style="stop-color:#23262c;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4188">
-      <stop
-         style="stop-color:#74868f;stop-opacity:1"
-         offset="0"
-         id="stop4190" />
-      <stop
-         id="stop4194"
-         offset="0.69999999"
-         style="stop-color:#d3d9dc;stop-opacity:1;" />
-      <stop
-         style="stop-color:#d6dddf;stop-opacity:1"
-         offset="1"
-         id="stop4192" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4177">
-      <stop
-         style="stop-color:#f2f2f2;stop-opacity:1"
-         offset="0"
-         id="stop4179" />
-      <stop
-         style="stop-color:#f9f9f9;stop-opacity:1"
-         offset="1"
-         id="stop4181" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4303-6"
-       id="linearGradient4643"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666726,0,0,0.68055543,128.19017,175.71333)"
-       x1="409.57144"
-       y1="543.79797"
-       x2="409.57144"
-       y2="502.65509" />
-    <linearGradient
-       id="linearGradient4303-6"
-       inkscape:collect="always">
-      <stop
-         id="stop4305-7"
+         id="stop4305"
          offset="0"
          style="stop-color:#c6cdd1;stop-opacity:1" />
       <stop
-         id="stop4307-0"
+         id="stop4307"
          offset="1"
          style="stop-color:#e0e5e7;stop-opacity:1" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4177"
-       id="linearGradient4183"
+       id="linearGradient5002">
+      <stop
+         style="stop-color:#2e5d89;stop-opacity:1"
+         offset="0"
+         id="stop5004" />
+      <stop
+         style="stop-color:#1b92f4;stop-opacity:1"
+         offset="1"
+         id="stop5006" />
+    </linearGradient>
+    <linearGradient
+       y2="527.79797"
+       x2="415.57144"
+       y1="512.79797"
        x1="400.57144"
-       y1="540.79797"
-       x2="400.57144"
-       y2="524.79797"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4188"
-       id="linearGradient4169"
-       x1="407.57144"
-       y1="536.79797"
-       x2="408.57144"
-       y2="536.79797"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4204"
-       id="linearGradient4202"
-       x1="407.57144"
-       y1="530.29797"
-       x2="408.57144"
-       y2="530.29797"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4222"
-       id="linearGradient4220"
-       x1="407.57144"
-       y1="538.29797"
-       x2="408.57144"
-       y2="538.29797"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4204"
-       id="linearGradient4241"
-       x1="23"
-       y1="23.5"
-       x2="24"
-       y2="23.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4227"
-       id="linearGradient4187"
-       x1="400.57144"
-       y1="525.79797"
-       x2="414.57147"
-       y2="539.79797"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-384.57143,-515.798)" />
+       id="linearGradient4352"
+       xlink:href="#linearGradient5002"
+       inkscape:collect="always"
+       gradientTransform="matrix(1.1818182,0,0,1.1818182,-74.285714,-95.732083)" />
     <linearGradient
-       id="linearGradient4227"
+       y2="527.79797"
+       x2="415.57144"
+       y1="512.79797"
+       x1="400.57144"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4352-6"
+       xlink:href="#linearGradient5002"
+       inkscape:collect="always"
+       gradientTransform="translate(78.999997,3.6562389)" />
+    <linearGradient
+       gradientTransform="matrix(1.1818182,0,0,1.1818182,6.714285,-89.23598)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient5002"
+       id="linearGradient4352-5"
+       gradientUnits="userSpaceOnUse"
+       x1="400.57144"
+       y1="512.79797"
+       x2="415.57144"
+       y2="527.79797" />
+    <linearGradient
+       gradientTransform="matrix(1.1818182,0,0,1.1818182,3.714275,-96.23596)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient5002"
+       id="linearGradient4352-9"
+       gradientUnits="userSpaceOnUse"
+       x1="400.57144"
+       y1="512.79797"
+       x2="415.57144"
+       y2="527.79797" />
+    <linearGradient
+       id="linearGradient4222"
        inkscape:collect="always">
       <stop
-         id="stop4229"
+         id="stop4224"
          offset="0"
-         style="stop-color:#292c2f;stop-opacity:1" />
+         style="stop-color:#147de1;stop-opacity:1" />
       <stop
-         id="stop4231"
+         style="stop-color:#88bff4;stop-opacity:1"
+         offset="0.69999999"
+         id="stop4226" />
+      <stop
+         id="stop4228"
          offset="1"
-         style="stop-color:#000000;stop-opacity:0;" />
+         style="stop-color:#3995ed;stop-opacity:1" />
     </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4204">
+      <stop
+         style="stop-color:#23262c;stop-opacity:1"
+         offset="0"
+         id="stop4206" />
+      <stop
+         id="stop4208"
+         offset="0.69999999"
+         style="stop-color:#4e5462;stop-opacity:1" />
+      <stop
+         style="stop-color:#23262c;stop-opacity:1"
+         offset="1"
+         id="stop4210" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4188"
+       inkscape:collect="always">
+      <stop
+         id="stop4190"
+         offset="0"
+         style="stop-color:#74868f;stop-opacity:1" />
+      <stop
+         style="stop-color:#d3d9dc;stop-opacity:1;"
+         offset="0.69999999"
+         id="stop4194" />
+      <stop
+         id="stop4192"
+         offset="1"
+         style="stop-color:#d6dddf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4177"
+       inkscape:collect="always">
+      <stop
+         id="stop4179"
+         offset="0"
+         style="stop-color:#f2f2f2;stop-opacity:1" />
+      <stop
+         id="stop4181"
+         offset="1"
+         style="stop-color:#f9f9f9;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="502.65509"
+       x2="409.57144"
+       y1="541.98621"
+       x1="409.4946"
+       gradientTransform="matrix(1.0833349,0,0,1.1059032,-34.048348,-55.586311)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4643"
+       xlink:href="#linearGradient4303"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="536.79797"
+       x2="408.57144"
+       y1="536.79797"
+       x1="407.34808"
+       id="linearGradient4169"
+       xlink:href="#linearGradient4188"
+       inkscape:collect="always"
+       gradientTransform="matrix(1.6348918,0,0,1.6348918,-246.39863,-346.45972)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="530.29797"
+       x2="408.57144"
+       y1="530.29797"
+       x1="407.34808"
+       id="linearGradient4202"
+       xlink:href="#linearGradient4204"
+       inkscape:collect="always"
+       gradientTransform="matrix(1.6348918,0,0,1.6348918,-246.39863,-346.45972)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="538.29797"
+       x2="408.57144"
+       y1="538.29797"
+       x1="407.34808"
+       id="linearGradient4220"
+       xlink:href="#linearGradient4222"
+       inkscape:collect="always"
+       gradientTransform="matrix(1.6348918,0,0,1.6348918,-246.39863,-346.45972)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="23.5"
+       x2="24"
+       y1="23.5"
+       x1="22.776661"
+       id="linearGradient4241"
+       xlink:href="#linearGradient4204"
+       inkscape:collect="always"
+       gradientTransform="matrix(1.6348918,0,0,1.6348918,382.33405,496.8142)" />
+    <linearGradient
+       gradientTransform="matrix(1.6250009,0,0,1.6250009,-242.35749,-341.12063)"
+       gradientUnits="userSpaceOnUse"
+       y2="539.79797"
+       x2="414.57147"
+       y1="525.79797"
+       x1="400.57144"
+       id="linearGradient4187"
+       xlink:href="#linearGradient4227"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4227">
+      <stop
+         style="stop-color:#292c2f;stop-opacity:1"
+         offset="0"
+         id="stop4229" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4231" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4177"
+       id="linearGradient4337"
+       x1="386.57144"
+       y1="525.79797"
+       x2="429.57144"
+       y2="525.79797"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -175,9 +234,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="11.181126"
-     inkscape:cx="3.3925798"
-     inkscape:cy="16.737115"
+     inkscape:zoom="0.125"
+     inkscape:cx="-1163.0533"
+     inkscape:cy="-189.05629"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -185,77 +244,49 @@
      fit-margin-left="0"
      fit-margin-right="0"
      fit-margin-bottom="0"
-     inkscape:window-width="1366"
-     inkscape:window-height="670"
-     inkscape:window-x="-4"
-     inkscape:window-y="29"
+     inkscape:window-width="1920"
+     inkscape:window-height="1006"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
      inkscape:showpageshadow="false"
      borderlayer="true"
-     showguides="true">
+     showguides="true"
+     inkscape:snap-bbox="true"
+     inkscape:object-nodes="true">
     <inkscape:grid
        type="xygrid"
-       id="grid4063" />
+       id="grid4063"
+       originx="7.9999866px"
+       originy="7.9999772px" />
     <sodipodi:guide
-       position="4.2167969e-05,32.000026"
-       orientation="32,0"
-       id="guide4625" />
-    <sodipodi:guide
-       position="4.2167969e-05,2.6367188e-05"
-       orientation="0,31.999969"
-       id="guide4627" />
-    <sodipodi:guide
-       position="32.000012,2.6367188e-05"
-       orientation="-32,0"
-       id="guide4629" />
-    <sodipodi:guide
-       position="32.000012,32.000026"
-       orientation="0,-31.999969"
-       id="guide4631" />
-    <sodipodi:guide
-       position="2.0000422,30.000026"
-       orientation="28,0"
-       id="guide4633" />
-    <sodipodi:guide
-       position="-44,2"
-       orientation="0,27.999969"
-       id="guide4635" />
-    <sodipodi:guide
-       position="30.000012,30.000026"
-       orientation="0,-27.999969"
-       id="guide4639" />
-    <sodipodi:guide
-       position="30,4"
-       orientation="0,-5"
-       id="guide4190" />
-    <sodipodi:guide
-       position="25,4"
-       orientation="0,5"
-       id="guide4192" />
-    <sodipodi:guide
-       position="30,4"
-       orientation="0,-1"
-       id="guide4194" />
-    <sodipodi:guide
-       position="29,4"
-       orientation="0,-1.5"
+       position="0,0"
+       orientation="0,64"
        id="guide4196" />
     <sodipodi:guide
-       position="16.000012,22.000026"
-       orientation="14,0"
-       id="guide4188" />
+       position="64,0"
+       orientation="-64,0"
+       id="guide4198" />
     <sodipodi:guide
-       position="16.000012,8.0000264"
-       orientation="0,14"
-       id="guide4191" />
+       position="64,64"
+       orientation="0,-64"
+       id="guide4200" />
     <sodipodi:guide
-       position="30.000012,8.0000264"
-       orientation="-14,0"
-       id="guide4193" />
+       position="6,58"
+       orientation="52,0"
+       id="guide4202" />
     <sodipodi:guide
-       position="30.000012,22.000026"
-       orientation="0,-14"
-       id="guide4195" />
+       position="6,6"
+       orientation="0,52"
+       id="guide4204" />
+    <sodipodi:guide
+       position="58,6"
+       orientation="-52,0"
+       id="guide4206" />
+    <sodipodi:guide
+       position="58,58"
+       orientation="0,-52"
+       id="guide4208" />
   </sodipodi:namedview>
   <metadata
      id="metadata5458">
@@ -273,87 +304,113 @@
      inkscape:label="Capa 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(-384.57143,-515.798)">
-    <rect
-       ry="0"
-       y="517.79797"
-       x="384.57144"
-       height="28"
-       width="32"
+     transform="translate(-376.57144,-491.79797)"
+     style="display:inline">
+    <path
+       id="circle4309-6"
+       style="opacity:1;fill:url(#linearGradient4352);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       r="9.9999886"
+       cy="519.79797"
+       cx="408.57144"
+       d=""
+       inkscape:connector-curvature="0" />
+    <path
+       id="circle4309-6-0"
+       style="opacity:1;fill:url(#linearGradient4352-6);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       r="9.9999886"
+       cy="519.79797"
+       cx="408.57144"
+       d=""
+       inkscape:connector-curvature="0" />
+    <path
+       id="circle4309-6-7"
+       style="opacity:1;fill:url(#linearGradient4352-5);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       r="9.9999886"
+       cy="519.79797"
+       cx="408.57144"
+       d=""
+       inkscape:connector-curvature="0" />
+    <path
+       id="circle4309-6-4"
+       style="opacity:1;fill:url(#linearGradient4352-9);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       r="9.9999886"
+       cy="519.79797"
+       cx="408.57144"
+       d=""
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
        id="rect4641"
+       d="m 382.57145,506.79799 52.00002,0 0,37.00357 -52.00002,0 z"
        style="opacity:1;fill:url(#linearGradient4643);fill-opacity:1;stroke:none" />
-    <rect
-       style="opacity:1;fill:#23262c;fill-opacity:1;stroke:none"
+    <path
+       style="opacity:1;fill:url(#linearGradient4337);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 386.57144,511.79799 43.99999,0 0,26.99998 -43.99999,0 z"
+       id="rect4329"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.2;fill:url(#linearGradient4187);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 421.57145,513.79799 -1.00002,23 8,8 6.00003,0 0,-17.99999 z"
+       id="path4179"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
        id="rect4647"
-       width="32"
-       height="5.0000262"
-       x="384.57144"
-       y="517.79797" />
-    <rect
-       style="opacity:1;fill:#3995ed;fill-opacity:1;stroke:none"
-       id="rect4171"
-       width="3"
-       height="1"
-       x="411.5715"
-       y="519.79797" />
-    <rect
-       y="519.79797"
-       x="386.57144"
-       height="1"
-       width="3"
-       id="rect4173"
-       style="opacity:1;fill:#ebf4fd;fill-opacity:1;stroke:none" />
-    <rect
-       style="opacity:1;fill:url(#linearGradient4183);fill-opacity:1;stroke:none"
-       id="rect4175"
-       width="26"
-       height="16"
-       x="387.57144"
-       y="524.79797" />
-    <rect
-       style="opacity:1;fill:#cad3d6;fill-opacity:1;stroke:none"
-       id="rect4185"
-       width="26"
-       height="1"
-       x="387.57144"
-       y="524.79797" />
-    <rect
-       style="opacity:1;fill:url(#linearGradient4202);fill-opacity:1.0;stroke:none"
+       d="m 382.57145,500.7932 52.00002,0 0,7.00448 -52.00002,0 z"
+       style="opacity:1;fill:#23262c;fill-opacity:1;stroke:none" />
+    <path
+       style="opacity:1;fill:url(#linearGradient4202);fill-opacity:1;stroke:none"
+       d="m 419.57143,513.79799 2.00003,0 0,12 -2.00003,0 z"
        id="rect4159"
-       width="0.99998838"
-       height="7.0000262"
-       x="407.57144"
-       y="526.79797" />
-    <rect
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
        style="opacity:1;fill:url(#linearGradient4169);fill-opacity:1;stroke:none"
+       d="m 419.57143,525.79799 2.00005,0 0,8.61876 -2.00005,0 z"
        id="rect4161"
-       width="1"
-       height="5.0000262"
-       x="407.57144"
-       y="533.79797" />
-    <rect
-       style="opacity:1;fill:url(#linearGradient4220);fill-opacity:1.0;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="opacity:1;fill:url(#linearGradient4220);fill-opacity:1;stroke:none"
+       d="m 419.57143,532.79799 2.00005,0 0,1.6187 -2.00005,0 z"
        id="rect4212"
-       width="1"
-       height="1"
-       x="407.57144"
-       y="537.79797" />
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
     <path
-       style="fill:url(#linearGradient4187);fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1;opacity:0.2"
-       d="M 24 11 L 23.5 24 L 27.5 28 L 29.5 30 L 32 30 L 32 19 L 30 17 L 24 11 z "
-       transform="translate(384.57143,515.798)"
-       id="path4179" />
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient4241);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 419.57143,534.41671 0,0.38128 1,2 1.00002,-2 0,-0.38128 z"
+       id="path4230"
+       sodipodi:nodetypes="cccccc" />
     <path
-       style="fill:url(#linearGradient4241);fill-opacity:1.0;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 23 23 L 23 23.300781 L 23.5 24 L 24 23.300781 L 24 23 L 23 23 z "
-       transform="translate(384.57143,515.798)"
-       id="path4230" />
-    <rect
        style="opacity:1;fill:#23262c;fill-opacity:1;stroke:none"
+       d="m 382.57144,542.79799 52.00003,0 0,2 -52.00003,0 z"
        id="rect4645"
-       width="32"
-       height="2"
-       x="384.57144"
-       y="543.79797" />
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       y="503.798"
+       x="385.57141"
+       height="1"
+       width="5"
+       id="rect4303"
+       style="opacity:1;fill:#ebf4fd;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="503.798"
+       x="426.57144"
+       height="1"
+       width="5"
+       id="rect4305"
+       style="opacity:1;fill:#3995ed;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:#cad3d6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 386.57144,510.79799 44,0 0,2.00001 -44,0 z"
+       id="rect4326"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
   </g>
 </svg>


### PR DESCRIPTION
I did a bigger version of the icon "preferences-desktop-peripherals" to use it as "input-tablet" on devices.

![input-tablet](https://cloud.githubusercontent.com/assets/1350839/12277359/af256a94-b959-11e5-9cad-63e175055c81.png)






